### PR TITLE
#136900 - finalize timeline changes to use hapi and user id to create…

### DIFF
--- a/languages/tribe-ext-hubspot.pot
+++ b/languages/tribe-ext-hubspot.pot
@@ -1,0 +1,202 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Project-Id-Version: Event Tickets HubSpot Integration\n"
+"POT-Creation-Date: 2019-12-03 18:01-0500\n"
+"PO-Revision-Date: 2019-12-03 18:00-0500\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.2.4\n"
+"X-Poedit-Basepath: ..\n"
+"X-Poedit-Flags-xgettext: --add-comments=translators:\n"
+"X-Poedit-WPHeader: tribe-ext-hubspot.php\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;"
+"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;"
+"_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-SearchPathExcluded-0: *.min.js\n"
+"X-Poedit-SearchPathExcluded-1: vendor\n"
+
+#: src/Tribe/Admin/Notices.php:102
+msgctxt "First part of notice there is no settings saved for HubSpot."
+msgid ""
+"HubSpot is missing the Credentials necessary to authorize your application. "
+"Please"
+msgstr ""
+
+#: src/Tribe/Admin/Notices.php:104
+msgctxt "Link text of notice there is no settings saved for HubSpot."
+msgid "set it in the settings."
+msgstr ""
+
+#: src/Tribe/Admin/Notices.php:190
+msgctxt "First part of notice there is no connection with HubSpot."
+msgid "HubSpot is not authorized."
+msgstr ""
+
+#: src/Tribe/Admin/Notices.php:192
+msgctxt "Link text of notice there is no connection with HubSpot."
+msgid "Please authorize or refresh your connection."
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:218
+msgid "APP ID"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:219
+msgid "Enter the app id from the application created in HubSpot"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:224
+msgid "Client ID"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:225
+msgid "Enter the client id from the application created in HubSpot"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:230
+msgid "Client Secret"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:231
+msgid "Enter the client secret from the application created in HubSpot"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:236
+msgid "User ID"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:237
+msgid "Enter the Developer Account User id for HubSpot"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:242
+msgid "HAPI Key"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:243
+msgid ""
+"Enter the Developer Account HAPI Key from the developer account in HubSpot"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:263
+msgctxt "API connection header"
+msgid "HubSpot"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:267
+msgctxt "Settings Description"
+msgid ""
+"You need to connect to your HubSpot account to be able to subscribe to "
+"actions."
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:295 src/Tribe/Admin/Settings.php:312
+msgid "HubSpot Connection"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:297
+msgid ""
+"An SSL is required to connect to HubSpot, please enable it on your site."
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:318
+msgid "You need to connect to HubSpot."
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:319
+msgid "Connect to HubSpot"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:321
+msgid "Refresh your connection to HubSpot"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:322
+msgid "Disconnect"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:453
+msgid "HubSpot Services"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:462
+msgctxt "Status Label HubSpot Main Connection."
+msgid "HubSpot Connection"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:463
+msgctxt "Status for HubSpot Main Connection."
+msgid "Not connected."
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:467
+msgctxt "Status for HubSpot Main Connection."
+msgid "Connected!"
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:507
+msgctxt "Message displayed when HubSpot Setup has not started."
+msgid "Setup on hold."
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:510
+msgctxt "This note is displayed when HubSpot Setup is Pending or In Progress."
+msgid ""
+"Setup can take up to 5 minutes. You may navigate away from this page and "
+"setup with continue in the background."
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:514
+msgctxt "Message displayed when HubSpot Setup is complete."
+msgid "Setup Complete."
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:517
+msgctxt "Message displayed when HubSpot Setup Failed."
+msgid "Setup incomplete, please refresh your connection to try again."
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:519
+msgctxt "Message displayed when HubSpot Setup has been initialized."
+msgid "Setup is preparing to begin. "
+msgstr ""
+
+#: src/Tribe/Admin/Settings.php:522
+msgctxt "Message displayed when HubSpot Setup is in Progress."
+msgid "Setup in Progress."
+msgstr ""
+
+#: src/Tribe/Setup.php:77
+#, php-format
+msgid ""
+"%1$s requires PHP version %2$s or newer to work. Please contact your website "
+"host and inquire about updating PHP."
+msgstr ""
+
+#. Plugin Name of the plugin/theme
+msgid "Event Tickets HubSpot Integration"
+msgstr ""
+
+#. Plugin URI of the plugin/theme
+msgid ""
+"https://theeventscalendar.com/extensions/---the-extension-article-url---/"
+msgstr ""
+
+#. Description of the plugin/theme
+msgid "Event Tickets and Event Tickets Plus HubSpot Integration"
+msgstr ""
+
+#. Author of the plugin/theme
+msgid "Modern Tribe, Inc."
+msgstr ""
+
+#. Author URI of the plugin/theme
+msgid "http://m.tri.be/1971"
+msgstr ""

--- a/src/Tribe/API/Connection.php
+++ b/src/Tribe/API/Connection.php
@@ -25,7 +25,17 @@ class Connection {
 	/**
 	 * @var int
 	 */
+	protected $user_id = '';
+
+	/**
+	 * @var int
+	 */
 	protected $app_id = '';
+
+	/**
+	 * @var string
+	 */
+	protected $hapi_key = '';
 
 	/**
 	 * @var string
@@ -63,7 +73,9 @@ class Connection {
 		$this->callback      = wp_nonce_url( get_home_url( null, '/tribe-hubspot/' ), 'hubspot-oauth-action', 'hubspot-oauth-nonce' );
 		$this->options       = tribe( 'tickets.hubspot' )->get_all_options();
 		$this->opts_prefix   = tribe( 'tickets.hubspot.admin.settings' )->get_options_prefix();
+		$this->user_id       = isset( $this->options['user_id'] ) ? $this->options['user_id'] : '';
 		$this->app_id        = isset( $this->options['app_id'] ) ? $this->options['app_id'] : '';
+		$this->hapi_key      = isset( $this->options['hapi_key'] ) ? $this->options['hapi_key'] : '';
 		$this->client_id     = isset( $this->options['client_id'] ) ? $this->options['client_id'] : '';
 		$this->client_secret = isset( $this->options['client_secret'] ) ? $this->options['client_secret'] : '';
 		$this->access_token  = isset( $this->options['access_token'] ) ? $this->options['access_token'] : '';
@@ -80,6 +92,17 @@ class Connection {
 	}
 
 	/**
+	 * Get the User ID.
+	 *
+	 * @since 1.0
+	 *
+	 * @return int The User ID.
+	 */
+	public function get_user_id() {
+		return $this->user_id;
+	}
+
+	/**
 	 * Get the Application ID.
 	 *
 	 * @since 1.0
@@ -88,6 +111,17 @@ class Connection {
 	 */
 	public function get_app_id() {
 		return $this->app_id;
+	}
+
+	/**
+	 * Get the HAPI Key.
+	 *
+	 * @since 1.0
+	 *
+	 * @return string The HAPI key.
+	 */
+	public function get_hapi_key() {
+		return $this->hapi_key;
 	}
 
 	/**
@@ -100,6 +134,8 @@ class Connection {
 	public function has_required_fields() {
 
 		if (
+			empty( $this->user_id ) ||
+			empty( $this->hapi_key ) ||
 			empty( $this->client_id ) ||
 			empty( $this->client_secret )
 		) {
@@ -122,6 +158,8 @@ class Connection {
 
 		// If missing any of these fields then the site is Not Authorized.
 		if (
+			empty( $this->user_id ) ||
+			empty( $this->hapi_key ) ||
 			empty( $this->client_id ) ||
 			empty( $this->client_secret ) ||
 			empty( $this->access_token ) ||

--- a/src/Tribe/API/Connection.php
+++ b/src/Tribe/API/Connection.php
@@ -25,17 +25,7 @@ class Connection {
 	/**
 	 * @var int
 	 */
-	protected $user_id = '';
-
-	/**
-	 * @var int
-	 */
 	protected $app_id = '';
-
-	/**
-	 * @var string
-	 */
-	protected $hapi_key = '';
 
 	/**
 	 * @var string
@@ -46,6 +36,16 @@ class Connection {
 	 * @var string
 	 */
 	protected $client_secret = '';
+
+	/**
+	 * @var int
+	 */
+	protected $user_id = '';
+
+	/**
+	 * @var string
+	 */
+	protected $hapi_key = '';
 
 	/**
 	 * @var string
@@ -73,11 +73,11 @@ class Connection {
 		$this->callback      = wp_nonce_url( get_home_url( null, '/tribe-hubspot/' ), 'hubspot-oauth-action', 'hubspot-oauth-nonce' );
 		$this->options       = tribe( 'tickets.hubspot' )->get_all_options();
 		$this->opts_prefix   = tribe( 'tickets.hubspot.admin.settings' )->get_options_prefix();
-		$this->user_id       = isset( $this->options['user_id'] ) ? $this->options['user_id'] : '';
 		$this->app_id        = isset( $this->options['app_id'] ) ? $this->options['app_id'] : '';
-		$this->hapi_key      = isset( $this->options['hapi_key'] ) ? $this->options['hapi_key'] : '';
 		$this->client_id     = isset( $this->options['client_id'] ) ? $this->options['client_id'] : '';
 		$this->client_secret = isset( $this->options['client_secret'] ) ? $this->options['client_secret'] : '';
+		$this->user_id       = isset( $this->options['user_id'] ) ? $this->options['user_id'] : '';
+		$this->hapi_key      = isset( $this->options['hapi_key'] ) ? $this->options['hapi_key'] : '';
 		$this->access_token  = isset( $this->options['access_token'] ) ? $this->options['access_token'] : '';
 		$this->refresh_token = isset( $this->options['refresh_token'] ) ? $this->options['refresh_token'] : '';
 		$this->token_expires = isset( $this->options['token_expires'] ) ? $this->options['token_expires'] : '';
@@ -134,10 +134,10 @@ class Connection {
 	public function has_required_fields() {
 
 		if (
-			empty( $this->user_id ) ||
-			empty( $this->hapi_key ) ||
 			empty( $this->client_id ) ||
-			empty( $this->client_secret )
+			empty( $this->client_secret ) ||
+			empty( $this->user_id ) ||
+			empty( $this->hapi_key )
 		) {
 
 			return false;
@@ -158,10 +158,10 @@ class Connection {
 
 		// If missing any of these fields then the site is Not Authorized.
 		if (
-			empty( $this->user_id ) ||
-			empty( $this->hapi_key ) ||
 			empty( $this->client_id ) ||
 			empty( $this->client_secret ) ||
+			empty( $this->user_id ) ||
+			empty( $this->hapi_key ) ||
 			empty( $this->access_token ) ||
 			empty( $this->refresh_token ) ||
 			empty( $this->token_expires )

--- a/src/Tribe/API/Timeline.php
+++ b/src/Tribe/API/Timeline.php
@@ -79,7 +79,7 @@ class Timeline {
 
 		$hapi_key        = $hubspot_api->get_hapi_key();
 		$client          = new Client( [ 'key' => $hapi_key ] );
-		$app_id          = $hubspot_api->get_app_id();
+		$app_id          = (int) $hubspot_api->get_app_id();
 		$timeline_events = $this->get_event_types();
 
 		foreach ( $this->timeline_event_types as $name => $event_type ) {

--- a/src/Tribe/API/Timeline.php
+++ b/src/Tribe/API/Timeline.php
@@ -79,7 +79,7 @@ class Timeline {
 
 		$hapi_key        = $hubspot_api->get_hapi_key();
 		$client          = new Client( [ 'key' => $hapi_key ] );
-		$app_id          = isset( $options['app_id'] ) ? (int) $options['app_id'] : '';
+		$app_id          = $hubspot_api->get_app_id();
 		$timeline_events = $this->get_event_types();
 
 		foreach ( $this->timeline_event_types as $name => $event_type ) {
@@ -211,9 +211,9 @@ class Timeline {
 			return false;
 		}
 
-		$client   = $hubspot_api->client;
-		$app_id   = isset( $hubspot_options['app_id'] ) ? $hubspot_options['app_id'] : '';;
-		$event_type_id = isset( $hubspot_options[ $type ] ) ? $hubspot_options[ $type ] : '';;
+		$client        = $hubspot_api->client;
+		$app_id        = $hubspot_api->get_app_id();
+		$event_type_id = isset( $hubspot_options[ $type ] ) ? $hubspot_options[ $type ] : '';
 
 		try {
 			$hubspot  = Factory::createWithOAuth2Token( $access_token, $client );

--- a/src/Tribe/API/Timeline.php
+++ b/src/Tribe/API/Timeline.php
@@ -3,6 +3,7 @@
 namespace Tribe\HubSpot\API;
 
 use SevenShores\Hubspot\Factory;
+use SevenShores\Hubspot\Http\Client;
 
 /**
  * Class Timeline
@@ -18,22 +19,22 @@ class Timeline {
 		'eventRegistration'     => [
 			'site_option'    => 'timeline_event_registration_id',
 			'headerTemplate' => 'Ticket purchase occurred at {{#formatDate timestamp}}{{/formatDate}} from the Event Tickets HubSpot Integration app',
-			'detailTemplate' => 'Purchased ticket for {{extraData.event.post_title}} (# {{extraData.event.ID}} )',
+			'detailTemplate' => 'Purchased ticket for {{extraData.event.event_name}} (#{{extraData.event.event_id}} )',
 		],
 		'eventRegistrationRSVP' => [
 			'site_option'    => 'timeline_event_registration_rsvp_id',
 			'headerTemplate' => 'RSVP occurred at {{#formatDate timestamp}}{{/formatDate}} from the Event Tickets HubSpot Integration app',
-			'detailTemplate' => 'RSVP\'d for {{extraData.event.post_title}} (# {{extraData.event.ID}} )',
+			'detailTemplate' => 'RSVP\'d for {{extraData.event.event_name}} (#{{extraData.event.event_id}} )',
 		],
 		'eventAttendeeUpdate'   => [
 			'site_option'    => 'timeline_event_attendee_update_id',
 			'headerTemplate' => 'Attendee Information update occurred at {{#formatDate timestamp}}{{/formatDate}} from the Event Tickets HubSpot Integration app',
-			'detailTemplate' => 'Updated Attendee Information for {{extraData.event.post_title}} (# {{extraData.event.ID}} )',
+			'detailTemplate' => 'Updated Attendee Information for {{extraData.event.event_name}} (#{{extraData.event.event_id}} )',
 		],
 		'eventCheckin'          => [
 			'site_option'    => 'timeline_event_checkin_id',
 			'headerTemplate' => 'Contact was successfully checked in at {{#formatDate timestamp}}{{/formatDate}}',
-			'detailTemplate' => 'Attendee was checked into {{extraData.event.post_title}} (# {{extraData.event.ID}} )',
+			'detailTemplate' => 'Attendee was checked into {{extraData.event.event_name}} (#{{extraData.event.event_id}} )',
 		],
 	];
 
@@ -76,7 +77,8 @@ class Timeline {
 			return false;
 		}
 
-		$client          = $hubspot_api->client;
+		$hapi_key        = $hubspot_api->get_hapi_key();
+		$client          = new Client( [ 'key' => $hapi_key ] );
 		$app_id          = isset( $options['app_id'] ) ? (int) $options['app_id'] : '';
 		$timeline_events = $this->get_event_types();
 
@@ -163,9 +165,9 @@ class Timeline {
 			return [];
 		}
 
-		$hubspot_options = tribe( 'tickets.hubspot' )->get_all_options();
-		$client          = $hubspot_api->client;
-		$app_id          = $hubspot_api->get_app_id();
+		$app_id   = $hubspot_api->get_app_id();
+		$hapi_key = $hubspot_api->get_hapi_key();
+		$client   = new Client( [ 'key' => $hapi_key ] );
 
 		try {
 			$hubspot  = Factory::createWithOAuth2Token( $access_token, $client );
@@ -209,8 +211,8 @@ class Timeline {
 			return false;
 		}
 
-		$client = $hubspot_api->client;
-		$app_id = isset( $hubspot_options['app_id'] ) ? $hubspot_options['app_id'] : '';;
+		$client   = $hubspot_api->client;
+		$app_id   = isset( $hubspot_options['app_id'] ) ? $hubspot_options['app_id'] : '';;
 		$event_type_id = isset( $hubspot_options[ $type ] ) ? $hubspot_options[ $type ] : '';;
 
 		try {

--- a/src/Tribe/Admin/Notices.php
+++ b/src/Tribe/Admin/Notices.php
@@ -99,9 +99,9 @@ class Notices {
 		] );
 
 		$message = sprintf( '<div><p>%s, <a href="%s" target="_blank">%s</a>.</p></div>',
-			esc_html_x( 'HubSpot is missing the Credentials necessary to authorize your application. Please', 'first part of notice there is no settings saved for HubSpot.', 'tribe-ext-hubspot' ),
+			esc_html_x( 'HubSpot is missing the Credentials necessary to authorize your application. Please', 'First part of notice there is no settings saved for HubSpot.', 'tribe-ext-hubspot' ),
 			esc_url( $url ),
-			esc_html_x( 'set it in the settings', 'link text of notice there is no settings saved for HubSpot.' , 'tribe-ext-hubspot' )
+			esc_html_x( 'set it in the settings.', 'Link text of notice there is no settings saved for HubSpot.' , 'tribe-ext-hubspot' )
 		);
 
 		return $message;
@@ -187,9 +187,9 @@ class Notices {
 
 
 		$message = sprintf( '<div><p>%s, <a href="%s" target="_blank">%s</a>.</p></div>',
-			esc_html_x( 'HubSpot is not authorized', 'first part of notice there is no connection with HubSpot.', 'tribe-ext-hubspot' ),
+			esc_html_x( 'HubSpot is not authorized.', 'First part of notice there is no connection with HubSpot.', 'tribe-ext-hubspot' ),
 			esc_url( $url ),
-			esc_html_x( 'Please authorize or refresh your token', 'link text of notice there is no connection with HubSpot.','tribe-ext-hubspot' )
+			esc_html_x( 'Please authorize or refresh your connection.', 'Link text of notice there is no connection with HubSpot.','tribe-ext-hubspot' )
 		);
 
 		return $message;

--- a/src/Tribe/Admin/Notices.php
+++ b/src/Tribe/Admin/Notices.php
@@ -56,11 +56,11 @@ class Notices {
 		$options = tribe( 'tickets.hubspot' )->get_all_options();
 
 		if (
-			! empty( $options[ 'user_id' ] ) &&
 			! empty( $options[ 'app_id' ] ) &&
-			! empty( $options[ 'hapi_key' ] ) &&
 			! empty( $options[ 'client_id' ] ) &&
-			! empty( $options[ 'client_secret' ] )
+			! empty( $options[ 'client_secret' ] ) &&
+			! empty( $options[ 'user_id' ] ) &&
+			! empty( $options[ 'hapi_key' ] )
 		) {
 			return;
 		}
@@ -133,11 +133,11 @@ class Notices {
 
 		// Bail if the Application Credentials are Empty.
 		if (
-			empty( $options[ 'user_id' ] ) ||
 			empty( $options[ 'app_id' ] ) ||
-			empty( $options[ 'hapi_key' ] ) ||
 			empty( $options[ 'client_id' ] ) ||
-			empty( $options[ 'client_secret' ] )
+			empty( $options[ 'client_secret' ] ) ||
+			empty( $options[ 'user_id' ] ) ||
+			empty( $options[ 'hapi_key' ] )
 		) {
 			return;
 		}

--- a/src/Tribe/Admin/Notices.php
+++ b/src/Tribe/Admin/Notices.php
@@ -55,7 +55,9 @@ class Notices {
 		// Bail if the Application Credentials are Saved.
 		$options       = tribe( 'tickets.hubspot' )->get_all_options();
 		if (
+			! empty( $options[ 'user_id' ] ) &&
 			! empty( $options[ 'app_id' ] ) &&
+			! empty( $options[ 'hapi_key' ] ) &&
 			! empty( $options[ 'client_id' ] ) &&
 			! empty( $options[ 'client_secret' ] )
 		) {
@@ -130,7 +132,9 @@ class Notices {
 
 		// Bail if the Application Credentials are Empty.
 		if (
+			empty( $options[ 'user_id' ] ) ||
 			empty( $options[ 'app_id' ] ) ||
+			empty( $options[ 'hapi_key' ] ) ||
 			empty( $options[ 'client_id' ] ) ||
 			empty( $options[ 'client_secret' ] )
 		) {

--- a/src/Tribe/Admin/Settings.php
+++ b/src/Tribe/Admin/Settings.php
@@ -309,7 +309,7 @@ class Settings {
 
 		?>
 		<fieldset id="tribe-field-hubspot_token" class="tribe-field tribe-field-text tribe-size-medium">
-			<legend class="tribe-field-label"><?php esc_html_e( 'HubSpot Token', 'tribe-ext-hubspot' ) ?></legend>
+			<legend class="tribe-field-label"><?php esc_html_e( 'HubSpot Connection', 'tribe-ext-hubspot' ) ?></legend>
 			<div class="tribe-field-wrap">
 				<?php
 				$authorize_link        = tribe( 'tickets.hubspot.api' )->get_authorized_url();

--- a/src/Tribe/Admin/Settings.php
+++ b/src/Tribe/Admin/Settings.php
@@ -213,22 +213,10 @@ class Settings {
 				'type' => 'html',
 				'html' => $this->get_authorize_fields(),
 			],
-			$this->opts_prefix . 'user_id' => [
-				'type'            => 'text',
-				'label'           => esc_html__( 'User ID', 'tribe-ext-hubspot' ),
-				'tooltip'         => sprintf( esc_html__( 'Enter the User id for HubSpot', 'tribe-ext-hubspot' ) ),
-				'validation_type' => 'html',
-			],
 			$this->opts_prefix . 'app_id' => [
 				'type'            => 'text',
 				'label'           => esc_html__( 'APP ID', 'tribe-ext-hubspot' ),
 				'tooltip'         => sprintf( esc_html__( 'Enter the app id from the application created in HubSpot', 'tribe-ext-hubspot' ) ),
-				'validation_type' => 'html',
-			],
-			$this->opts_prefix . 'hapi_key' => [
-				'type'            => 'text',
-				'label'           => esc_html__( 'HAPI Key', 'tribe-ext-hubspot' ),
-				'tooltip'         => sprintf( esc_html__( 'Enter the HAPI Key from the developer account in HubSpot', 'tribe-ext-hubspot' ) ),
 				'validation_type' => 'html',
 			],
 			$this->opts_prefix . 'client_id'      => [
@@ -241,6 +229,18 @@ class Settings {
 				'type'            => 'text',
 				'label'           => esc_html__( 'Client Secret of the OAuth app', 'tribe-ext-hubspot' ),
 				'tooltip'         => sprintf( esc_html__( 'Enter the client secret from the application created in HubSpot', 'tribe-ext-hubspot' ) ),
+				'validation_type' => 'html',
+			],
+			$this->opts_prefix . 'user_id' => [
+				'type'            => 'text',
+				'label'           => esc_html__( 'User ID', 'tribe-ext-hubspot' ),
+				'tooltip'         => sprintf( esc_html__( 'Enter the Developer Account User id for HubSpot', 'tribe-ext-hubspot' ) ),
+				'validation_type' => 'html',
+			],
+			$this->opts_prefix . 'hapi_key' => [
+				'type'            => 'text',
+				'label'           => esc_html__( 'HAPI Key', 'tribe-ext-hubspot' ),
+				'tooltip'         => sprintf( esc_html__( 'Enter the Developer Account HAPI Key from the developer account in HubSpot', 'tribe-ext-hubspot' ) ),
 				'validation_type' => 'html',
 			],
 		];

--- a/src/Tribe/Admin/Settings.php
+++ b/src/Tribe/Admin/Settings.php
@@ -221,13 +221,13 @@ class Settings {
 			],
 			$this->opts_prefix . 'client_id'      => [
 				'type'            => 'text',
-				'label'           => esc_html__( 'Client ID of the OAuth app', 'tribe-ext-hubspot' ),
+				'label'           => esc_html__( 'Client ID', 'tribe-ext-hubspot' ),
 				'tooltip'         => sprintf( esc_html__( 'Enter the client id from the application created in HubSpot', 'tribe-ext-hubspot' ) ),
 				'validation_type' => 'html',
 			],
 			$this->opts_prefix . 'client_secret'  => [
 				'type'            => 'text',
-				'label'           => esc_html__( 'Client Secret of the OAuth app', 'tribe-ext-hubspot' ),
+				'label'           => esc_html__( 'Client Secret', 'tribe-ext-hubspot' ),
 				'tooltip'         => sprintf( esc_html__( 'Enter the client secret from the application created in HubSpot', 'tribe-ext-hubspot' ) ),
 				'validation_type' => 'html',
 			],
@@ -264,7 +264,7 @@ class Settings {
 		</h3>
 		<div style="margin-left: 20px;">
 			<p>
-				<?php echo esc_html_x( 'You need to connect to your HubSpot account to be able to subscribe to actions.', 'Settings', 'tribe-ext-hubspot' ); ?>
+				<?php echo esc_html_x( 'You need to connect to your HubSpot account to be able to subscribe to actions.', 'Settings Description', 'tribe-ext-hubspot' ); ?>
 			</p>
 		</div>
 		<?php
@@ -315,7 +315,7 @@ class Settings {
 				$authorize_link        = tribe( 'tickets.hubspot.api' )->get_authorized_url();
 
 				if ( $missing_hubspot_credentials ) {
-					echo '<p>' . esc_html__( 'You need to connect to HubSpot.' ) . '</p>';
+					echo '<p>' . esc_html__( 'You need to connect to HubSpot.', 'tribe-ext-hubspot' ) . '</p>';
 					$hubspot_button_label = __( 'Connect to HubSpot', 'tribe-ext-hubspot' );
 				} else {
 					$hubspot_button_label     = __( 'Refresh your connection to HubSpot', 'tribe-ext-hubspot' );

--- a/src/Tribe/Admin/Settings.php
+++ b/src/Tribe/Admin/Settings.php
@@ -213,10 +213,22 @@ class Settings {
 				'type' => 'html',
 				'html' => $this->get_authorize_fields(),
 			],
+			$this->opts_prefix . 'user_id' => [
+				'type'            => 'text',
+				'label'           => esc_html__( 'User ID', 'tribe-ext-hubspot' ),
+				'tooltip'         => sprintf( esc_html__( 'Enter the User id for HubSpot', 'tribe-ext-hubspot' ) ),
+				'validation_type' => 'html',
+			],
 			$this->opts_prefix . 'app_id' => [
 				'type'            => 'text',
 				'label'           => esc_html__( 'APP ID', 'tribe-ext-hubspot' ),
 				'tooltip'         => sprintf( esc_html__( 'Enter the app id from the application created in HubSpot', 'tribe-ext-hubspot' ) ),
+				'validation_type' => 'html',
+			],
+			$this->opts_prefix . 'hapi_key' => [
+				'type'            => 'text',
+				'label'           => esc_html__( 'HAPI Key', 'tribe-ext-hubspot' ),
+				'tooltip'         => sprintf( esc_html__( 'Enter the HAPI Key from the developer account in HubSpot', 'tribe-ext-hubspot' ) ),
 				'validation_type' => 'html',
 			],
 			$this->opts_prefix . 'client_id'      => [
@@ -280,7 +292,7 @@ class Settings {
 			ob_start();
 			?>
 			<fieldset id="tribe-field-hubspot_token" class="tribe-field tribe-field-text tribe-size-medium">
-				<legend class="tribe-field-label"><?php esc_html_e( 'HubSpot Token', 'tribe-ext-hubspot' ) ?></legend>
+				<legend class="tribe-field-label"><?php esc_html_e( 'HubSpot Connection', 'tribe-ext-hubspot' ) ?></legend>
 				<div class="tribe-field-wrap tribe-error">
 					<?php esc_html_e( 'An SSL is required to connect to HubSpot, please enable it on your site.', 'tribe-ext-hubspot' ) ?>
 				</div>

--- a/src/Tribe/Properties/Event_Data.php
+++ b/src/Tribe/Properties/Event_Data.php
@@ -194,7 +194,7 @@ class Event_Data {
 	/**
 	 * Determine if a Post Type is a Tribe Event.
 	 *
-	 * @param string $post_type Post Type Name.
+	 * @param string $post_type The post type name.
 	 *
 	 * @return bool Whether a post type is a TEC event.
 	 */

--- a/src/Tribe/Properties/Event_Data.php
+++ b/src/Tribe/Properties/Event_Data.php
@@ -20,10 +20,10 @@ class Event_Data {
 	 */
 	public function get_event_values( $prefix, $post_id ) {
 
-		$event      = tribe_get_event( $post_id );
+		$event = tribe_get_event( $post_id );
+		$is_event = $this->is_tribe_event( $event->post_type );
 
 		$event_data = [
-			//todo number formatting is 16,108 in HubSpot
 			[
 				'property' => $prefix . 'event_id',
 				'value'    => $event->ID,
@@ -45,20 +45,20 @@ class Event_Data {
 				'value'    => html_entity_decode( $event->cost ),
 			],
 			[
-				'property' => $prefix . 'event_start_datetime_utc',
-				'value'    => ms_timestamp( strtotime( 'midnight', ( \Tribe__Date_Utils::wp_strtotime( $event->start_date_utc ) ) ) ),
+				'property' => $prefix . 'event_start_date_utc',
+				'value'    => $is_event ? ms_timestamp( strtotime( 'midnight', ( \Tribe__Date_Utils::wp_strtotime( $event->start_date_utc ) ) ) ) : null,
 			],
 			[
-				'property' => $prefix . 'event_start_time_utc',
-				'value'    =>  ms_timestamp( date( 'U', strtotime( $event->start_date_utc ) ) ),
+				'property' => $prefix . 'event_start_datetime_utc',
+				'value'    => $is_event ? ms_timestamp( date( 'U', strtotime( $event->start_date_utc ) ) ) : null,
 			],
 			[
 				'property' => $prefix . 'event_timezone',
-				'value'    => $event->timezone,
+				'value'    => $is_event ? $event->timezone : null,
 			],
 			[
 				'property' => $prefix . 'event_duration',
-				'value'    => $event->duration,
+				'value'    => $is_event ? $event->duration : null,
 			],
 		];
 
@@ -189,6 +189,22 @@ class Event_Data {
 
 		return $ticket_data;
 
+	}
+
+	/**
+	 * Determine if a Post Type is a Tribe Event.
+	 *
+	 * @param string $post_type Post Type Name.
+	 *
+	 * @return bool True or false the post type.
+	 */
+	protected function is_tribe_event( $post_type ) {
+
+		 if ( 'tribe_events' === $post_type ) {
+		 	return true;
+         }
+
+         return false;
 	}
 
 	/**

--- a/src/Tribe/Properties/Event_Data.php
+++ b/src/Tribe/Properties/Event_Data.php
@@ -196,7 +196,7 @@ class Event_Data {
 	 *
 	 * @param string $post_type Post Type Name.
 	 *
-	 * @return bool True or false the post type.
+	 * @return bool Whether a post type is a TEC event.
 	 */
 	protected function is_tribe_event( $post_type ) {
 

--- a/src/Tribe/Properties/Event_Data.php
+++ b/src/Tribe/Properties/Event_Data.php
@@ -192,7 +192,7 @@ class Event_Data {
 	}
 
 	/**
-	 * Determine if a Post Type is a Tribe Event.
+	 * Determine whether a post type is a TEC event.
 	 *
 	 * @param string $post_type The post type name.
 	 *

--- a/src/Tribe/Properties/Last_Attended_Event.php
+++ b/src/Tribe/Properties/Last_Attended_Event.php
@@ -93,15 +93,16 @@ class Last_Attended_Event extends Base {
 				'type'      => 'string',
 				'fieldType' => 'text',
 			],
-			'last_attended_event_start_datetime_utc'   => [
+			'last_attended_event_start_date_utc'   => [
 				'label'     => 'Last Attended Event Start Datetime (UTC)',
 				'groupName' => $this->group_name,
 				'type'      => 'date',
 				'fieldType' => 'date',
 			],
-			'last_attended_event_start_time_utc'       => [
+			'last_attended_event_start_datetime_utc' => [
 				'label'     => 'Last Attended Event Start Time (UTC)',
 				'groupName' => $this->group_name,
+				'fieldType' => 'datetime',
 				'type'      => 'datetime',
 			],
 			'last_attended_event_timezone'             => [

--- a/src/Tribe/Properties/Last_Attended_Event.php
+++ b/src/Tribe/Properties/Last_Attended_Event.php
@@ -94,13 +94,13 @@ class Last_Attended_Event extends Base {
 				'fieldType' => 'text',
 			],
 			'last_attended_event_start_date_utc'   => [
-				'label'     => 'Last Attended Event Start Datetime (UTC)',
+				'label'     => 'Last Attended Event Start Date (UTC)',
 				'groupName' => $this->group_name,
 				'type'      => 'date',
 				'fieldType' => 'date',
 			],
 			'last_attended_event_start_datetime_utc' => [
-				'label'     => 'Last Attended Event Start Time (UTC)',
+				'label'     => 'Last Attended Event Start DateTime (UTC)',
 				'groupName' => $this->group_name,
 				'fieldType' => 'datetime',
 				'type'      => 'datetime',

--- a/src/Tribe/Properties/Last_Registered_Event.php
+++ b/src/Tribe/Properties/Last_Registered_Event.php
@@ -93,14 +93,13 @@ class Last_Registered_Event extends Base {
 				'type'      => 'string',
 				'fieldType' => 'text',
 			],
-			'last_registered_event_start_datetime_utc'   => [
+			'last_registered_event_start_date_utc'   => [
 				'label'     => 'Last Registered Event Start Datetime (UTC)',
 				'groupName' => $this->group_name,
 				'type'      => 'date',
 				'fieldType' => 'date',
 			],
-			//todo broken broken
-			'last_registered_event_start_time_utc'       => [
+			'last_registered_event_start_datetime_utc'       => [
 				'label'     => 'Last Registered Event Start Time (UTC)',
 				'groupName' => $this->group_name,
 				'type'      => 'datetime',

--- a/src/Tribe/Properties/Last_Registered_Event.php
+++ b/src/Tribe/Properties/Last_Registered_Event.php
@@ -94,13 +94,13 @@ class Last_Registered_Event extends Base {
 				'fieldType' => 'text',
 			],
 			'last_registered_event_start_date_utc'   => [
-				'label'     => 'Last Registered Event Start Datetime (UTC)',
+				'label'     => 'Last Registered Event Start Date (UTC)',
 				'groupName' => $this->group_name,
 				'type'      => 'date',
 				'fieldType' => 'date',
 			],
 			'last_registered_event_start_datetime_utc'       => [
-				'label'     => 'Last Registered Event Start Time (UTC)',
+				'label'     => 'Last Registered Event Start DateTime (UTC)',
 				'groupName' => $this->group_name,
 				'type'      => 'datetime',
 				'fieldType' => 'datetime',

--- a/src/Tribe/Service_Provider.php
+++ b/src/Tribe/Service_Provider.php
@@ -63,7 +63,6 @@ class Service_Provider extends \tad_DI52_ServiceProvider {
 	 */
 	protected function hook() {
 
-		//todo change these to only load when required during Sprint 4
 		tribe( 'tickets.hubspot.oauth' );
 		add_action( 'tribe_hubspot_authorize_site', tribe_callback( 'tickets.hubspot.api', 'save_access_token' ) );
 

--- a/src/Tribe/Subscribe/Base.php
+++ b/src/Tribe/Subscribe/Base.php
@@ -216,18 +216,17 @@ abstract class Base {
 	 *
 	 * @param array  $attendee_data An array of contact information for the attendee.
 	 * @param string $type_site_id  The name of the site option field of event to create ( Registration, Update, Check-In ).
-	 * @param int    $post_id       The ID of an event.
-	 * @param int    $attendee_id   The ID of an attendee.
+	 * @param string $timeline_id   The unique id used in HubSpot.
 	 * @param array  $extra_data    An array of event and ticket data to include with the Timeline Event.
 	 */
-	public function maybe_push_to_timeline_queue( $attendee_data, $type_site_id, $post_id, $attendee_id, $extra_data ) {
+	public function maybe_push_to_timeline_queue( $attendee_data, $type_site_id, $timeline_id, $extra_data ) {
 
 		if ( ! empty( $attendee_data['email'] ) ) {
 
 			$hubspot_data = [
 				'type'              => 'timeline',
 				'event_type'        => $type_site_id,
-				'timeline_event_id' => "event-checkin:{$post_id}:{$attendee_id}",
+				'timeline_event_id' => $timeline_id,
 				'email'             => $attendee_data['email'],
 				'extra_data'        => $extra_data,
 			];

--- a/src/Tribe/Subscribe/EDD.php
+++ b/src/Tribe/Subscribe/EDD.php
@@ -54,7 +54,7 @@ class EDD extends Base {
 		$extra_data = $this->get_extra_data( $post_id, $product_id, $attendee_id, 'edd', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_registration_id', $post_id, $attendee_id, $extra_data );
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_registration_id', "event-register:{$post_id}:{$attendee_id}", $extra_data );
 	}
 
 	/**
@@ -88,7 +88,7 @@ class EDD extends Base {
 		$extra_data = $this->get_extra_data( $related_data['post_id'], $related_data['ticket_id'], $attendee_id, 'edd', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', $post_id, $attendee_id, $extra_data );
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', "attendee-update:{$related_data['post_id']}:{$attendee_id}", $extra_data );
 	}
 
 	/**
@@ -114,7 +114,7 @@ class EDD extends Base {
 		$extra_data = $this->get_extra_data( $related_data['post_id'], $related_data['ticket_id'], $attendee_id, 'edd', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_checkin_id', $related_data['post_id'], $attendee_id, $extra_data );
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_checkin_id', "event-checkin:{$related_data['post_id']}:{$attendee_id}", $extra_data );
 	}
 
 	/**

--- a/src/Tribe/Subscribe/EDD.php
+++ b/src/Tribe/Subscribe/EDD.php
@@ -88,7 +88,8 @@ class EDD extends Base {
 		$extra_data = $this->get_extra_data( $related_data['post_id'], $related_data['ticket_id'], $attendee_id, 'edd', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', "attendee-update:{$related_data['post_id']}:{$attendee_id}", $extra_data );
+		$time = time();
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', "attendee-update:{$related_data['post_id']}:{$attendee_id}:{$time}", $extra_data );
 	}
 
 	/**

--- a/src/Tribe/Subscribe/RSVP.php
+++ b/src/Tribe/Subscribe/RSVP.php
@@ -88,7 +88,8 @@ class RSVP extends Base {
 		$extra_data = $this->get_extra_data( $related_data['post_id'], $related_data['ticket_id'], $order_id, 'rsvp', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', "attendee-update:{$related_data['post_id']}:{$order_id}", $extra_data );
+		$time = time();
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', "attendee-update:{$related_data['post_id']}:{$order_id}:{$time}", $extra_data );
 	}
 
 	/**

--- a/src/Tribe/Subscribe/RSVP.php
+++ b/src/Tribe/Subscribe/RSVP.php
@@ -54,7 +54,8 @@ class RSVP extends Base {
 		$extra_data = $this->get_extra_data( $post_id, $product_id, $attendee_id, 'rsvp', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_registration_id', $post_id, $attendee_id, $extra_data );
+		$time = time();
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_registration_rsvp_id', "event-register:{$post_id}:{$attendee_id}:{$time}", $extra_data );
 	}
 
 	/**
@@ -88,7 +89,8 @@ class RSVP extends Base {
 		$extra_data = $this->get_extra_data( $related_data['post_id'], $related_data['ticket_id'], $order_id, 'rsvp', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', $event_id, $order_id, $extra_data );
+		$time = time();
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', "attendee-update:{$related_data['post_id']}:{$order_id}:{$time}", $extra_data );
 	}
 
 	/**
@@ -114,7 +116,8 @@ class RSVP extends Base {
 		$extra_data = $this->get_extra_data( $related_data['post_id'], $related_data['ticket_id'], $attendee_id, 'rsvp', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		//$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_checkin_id', $related_data['post_id'], $attendee_id, $extra_data );
+		$time = time();
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_checkin_id', "event-checkin:{$related_data['post_id']}:{$attendee_id}:{$time}", $extra_data );
 	}
 
 	/**
@@ -159,8 +162,8 @@ class RSVP extends Base {
 
 		$related_data['order_id']  = get_post_meta( $attendee_id, $rsvp->order_key, true );
 		$related_data['order']     = $rsvp->get_attendees_by_id( $related_data['order_id'] );
-		$related_data['post_id']   = get_post_meta( $attendee_id, $rsvp->attendee_event_key, true );
-		$related_data['ticket_id'] = get_post_meta( $attendee_id, $rsvp->attendee_product_key, true );
+		$related_data['post_id']   = get_post_meta( $attendee_id, $rsvp::ATTENDEE_EVENT_KEY, true );
+		$related_data['ticket_id'] = get_post_meta( $attendee_id, $rsvp::ATTENDEE_PRODUCT_KEY, true );
 
 		return $related_data;
 	}

--- a/src/Tribe/Subscribe/RSVP.php
+++ b/src/Tribe/Subscribe/RSVP.php
@@ -54,8 +54,7 @@ class RSVP extends Base {
 		$extra_data = $this->get_extra_data( $post_id, $product_id, $attendee_id, 'rsvp', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$time = time();
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_registration_rsvp_id', "event-register:{$post_id}:{$attendee_id}:{$time}", $extra_data );
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_registration_rsvp_id', "event-register:{$post_id}:{$attendee_id}", $extra_data );
 	}
 
 	/**
@@ -89,8 +88,7 @@ class RSVP extends Base {
 		$extra_data = $this->get_extra_data( $related_data['post_id'], $related_data['ticket_id'], $order_id, 'rsvp', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$time = time();
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', "attendee-update:{$related_data['post_id']}:{$order_id}:{$time}", $extra_data );
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', "attendee-update:{$related_data['post_id']}:{$order_id}", $extra_data );
 	}
 
 	/**
@@ -116,8 +114,7 @@ class RSVP extends Base {
 		$extra_data = $this->get_extra_data( $related_data['post_id'], $related_data['ticket_id'], $attendee_id, 'rsvp', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$time = time();
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_checkin_id', "event-checkin:{$related_data['post_id']}:{$attendee_id}:{$time}", $extra_data );
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_checkin_id', "event-checkin:{$related_data['post_id']}:{$attendee_id}", $extra_data );
 	}
 
 	/**

--- a/src/Tribe/Subscribe/TPP.php
+++ b/src/Tribe/Subscribe/TPP.php
@@ -49,7 +49,7 @@ class TPP extends Base {
 		$extra_data = $this->get_extra_data( $post_id, $product_id, $attendee_id, 'tpp', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_registration_id', $post_id, $attendee_id, $extra_data );
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_registration_id', "event-register:{$post_id}:{$attendee_id}", $extra_data );
 	}
 
 	/**
@@ -83,7 +83,7 @@ class TPP extends Base {
 		$extra_data = $this->get_extra_data( $related_data['post_id'], $related_data['ticket_id'], $attendee_id, 'tpp', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', $post_id, $attendee_id, $extra_data );
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', "attendee-update:{$related_data['post_id']}:{$attendee_id}", $extra_data );
 	}
 
 	/**
@@ -109,7 +109,7 @@ class TPP extends Base {
 		$extra_data = $this->get_extra_data( $related_data['post_id'], $related_data['ticket_id'], $attendee_id, 'tpp', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_checkin_id', $related_data['post_id'], $attendee_id, $extra_data );
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_checkin_id', "event-checkin:{$related_data['post_id']}:{$attendee_id}", $extra_data );
 	}
 
 	/**

--- a/src/Tribe/Subscribe/TPP.php
+++ b/src/Tribe/Subscribe/TPP.php
@@ -83,7 +83,8 @@ class TPP extends Base {
 		$extra_data = $this->get_extra_data( $related_data['post_id'], $related_data['ticket_id'], $attendee_id, 'tpp', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', "attendee-update:{$related_data['post_id']}:{$attendee_id}", $extra_data );
+		$time = time();
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', "attendee-update:{$related_data['post_id']}:{$attendee_id}:{$time}", $extra_data );
 	}
 
 	/**

--- a/src/Tribe/Subscribe/Woo.php
+++ b/src/Tribe/Subscribe/Woo.php
@@ -49,7 +49,7 @@ class Woo extends Base {
 		$extra_data = $this->get_extra_data( $post_id, $product_id, $attendee_id, 'woo', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_registration_id', $post_id, $attendee_id, $extra_data );
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_registration_id', "event-register:{$post_id}:{$attendee_id}", $extra_data );
 	}
 
 	/**
@@ -83,7 +83,7 @@ class Woo extends Base {
 		$extra_data = $this->get_extra_data( $related_data['post_id'], $related_data['ticket_id'], $attendee_id, 'woo', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', $post_id, $attendee_id, $extra_data );
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', "attendee-update:{$related_data['post_id']}:{$attendee_id}", $extra_data );
 	}
 
 	/**
@@ -109,7 +109,7 @@ class Woo extends Base {
 		$extra_data = $this->get_extra_data( $related_data['post_id'], $related_data['ticket_id'], $attendee_id, 'woo', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_checkin_id', $related_data['post_id'], $attendee_id, $extra_data );
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_checkin_id', "event-checkin:{$related_data['post_id']}:{$attendee_id}", $extra_data );
 	}
 
 	/**

--- a/src/Tribe/Subscribe/Woo.php
+++ b/src/Tribe/Subscribe/Woo.php
@@ -83,7 +83,8 @@ class Woo extends Base {
 		$extra_data = $this->get_extra_data( $related_data['post_id'], $related_data['ticket_id'], $attendee_id, 'woo', $attendee_data['name'] );
 
 		// Maybe Queue Creating a Timeline Event in HubSpot.
-		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', "attendee-update:{$related_data['post_id']}:{$attendee_id}", $extra_data );
+		$time = time();
+		$this->maybe_push_to_timeline_queue( $attendee_data, 'timeline_event_attendee_update_id', "attendee-update:{$related_data['post_id']}:{$attendee_id}:{$time}", $extra_data );
 	}
 
 	/**


### PR DESCRIPTION
… and get types, but Oauth for creating timeline events and fixes to RSVP

-Adds HAPI Key and User ID for Timeline Event Type Creation and Getting
-Changes Timeline Event to use the HAPI Key and User ID when setting up
-Fixes to RSVP
-Fixes to Timeline Event Template Extra Data
-Add time() to the timeline event custom id to make it unique and fix labeling of custom id
-Misc Text Changes
-Match custom date and datetime custom property names to the field type names