### PR TITLE
#138243 - text updates, required version updates, addition is ready check

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,6 @@ We're always interested in your feedback and our [Help Desk](https://support.the
 
 == Changelog ==
 
-= [1.0.0] YYYY-MM-DD =
+= [1.0.0] 2019-12-DD =
 
 * Initial release

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,6 @@ We're always interested in your feedback and our [Help Desk](https://support.the
 
 == Changelog ==
 
-= [1.0.0] 2019-12-DD =
+= [1.0.0] 2019-12-10 =
 
 * Initial release

--- a/readme.txt
+++ b/readme.txt
@@ -13,11 +13,9 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 == Description ==
 
-Automatically create/update contacts in HubSpot for both the buyer and the attendees when a ticket is purchased
+Updates to a user's attendee meta or RSVP status will be synced with HubSpot.
 
-Updates to user or attendee records should be synced with HubSpot
-
-Event meta for the RSVP/Ticket will be associated with the HubSpot contact and timeline
+When a user is checked into an event, that event will sync to the HubSpot contact and timeline.
 
 == Installation ==
 
@@ -39,6 +37,6 @@ We're always interested in your feedback and our [Help Desk](https://support.the
 
 == Changelog ==
 
-= [1.0.0] 2019-12-10 =
+= [1.0.0] 2019-12-11 =
 
 * Initial release

--- a/src/Tribe/API/Connection.php
+++ b/src/Tribe/API/Connection.php
@@ -70,17 +70,20 @@ class Connection {
 	 */
 	public function __construct() {
 
-		$this->callback      = wp_nonce_url( get_home_url( null, '/tribe-hubspot/' ), 'hubspot-oauth-action', 'hubspot-oauth-nonce' );
-		$this->options       = tribe( 'tickets.hubspot' )->get_all_options();
-		$this->opts_prefix   = tribe( 'tickets.hubspot.admin.settings' )->get_options_prefix();
-		$this->app_id        = isset( $this->options['app_id'] ) ? $this->options['app_id'] : '';
-		$this->client_id     = isset( $this->options['client_id'] ) ? $this->options['client_id'] : '';
-		$this->client_secret = isset( $this->options['client_secret'] ) ? $this->options['client_secret'] : '';
-		$this->user_id       = isset( $this->options['user_id'] ) ? $this->options['user_id'] : '';
-		$this->hapi_key      = isset( $this->options['hapi_key'] ) ? $this->options['hapi_key'] : '';
-		$this->access_token  = isset( $this->options['access_token'] ) ? $this->options['access_token'] : '';
-		$this->refresh_token = isset( $this->options['refresh_token'] ) ? $this->options['refresh_token'] : '';
-		$this->token_expires = isset( $this->options['token_expires'] ) ? $this->options['token_expires'] : '';
+		$this->callback                   = wp_nonce_url( get_home_url( null, '/tribe-hubspot/' ), 'hubspot-oauth-action', 'hubspot-oauth-nonce' );
+		$this->options                    = tribe( 'tickets.hubspot' )->get_all_options();
+		$this->opts_prefix                = tribe( 'tickets.hubspot.admin.settings' )->get_options_prefix();
+		$this->app_id                     = isset( $this->options['app_id'] ) ? $this->options['app_id'] : '';
+		$this->client_id                  = isset( $this->options['client_id'] ) ? $this->options['client_id'] : '';
+		$this->client_secret              = isset( $this->options['client_secret'] ) ? $this->options['client_secret'] : '';
+		$this->user_id                    = isset( $this->options['user_id'] ) ? $this->options['user_id'] : '';
+		$this->hapi_key                   = isset( $this->options['hapi_key'] ) ? $this->options['hapi_key'] : '';
+		$this->access_token               = isset( $this->options['access_token'] ) ? $this->options['access_token'] : '';
+		$this->refresh_token              = isset( $this->options['refresh_token'] ) ? $this->options['refresh_token'] : '';
+		$this->token_expires              = isset( $this->options['token_expires'] ) ? $this->options['token_expires'] : '';
+		$this->group_name_setup           = isset( $this->options['group_name_setup'] ) ? $this->options['group_name_setup'] : '';
+		$this->custom_properties_setup    = isset( $this->options['custom_properties_setup'] ) ? $this->options['custom_properties_setup'] : '';
+		$this->timeline_event_types_setup = isset( $this->options['timeline_event_types_setup'] ) ? $this->options['timeline_event_types_setup'] : '';
 
 		if ( ! $this->has_required_fields() ) {
 			return;
@@ -285,7 +288,7 @@ class Connection {
 	}
 
 	/**
-	 * Maybe Refresh the Token if Expired or within a Minute of Expiring
+	 * Determine if the API has Valid Access Token and Setup is complete with HubSpot
 	 *
 	 * @since 1.0
 	 *
@@ -300,6 +303,14 @@ class Connection {
 		$access_token = $this->maybe_refresh( $this->access_token );
 
 		if ( ! $access_token ) {
+			return false;
+		}
+
+		if (
+			'complete' !== $this->group_name_setup ||
+			'complete' !== $this->custom_properties_setup ||
+			'complete' !== $this->timeline_event_types_setup
+		) {
 			return false;
 		}
 

--- a/src/Tribe/API/Timeline.php
+++ b/src/Tribe/API/Timeline.php
@@ -34,7 +34,7 @@ class Timeline {
 		'eventCheckin'          => [
 			'site_option'    => 'timeline_event_checkin_id',
 			'headerTemplate' => 'Contact was successfully checked in at {{#formatDate timestamp}}{{/formatDate}}',
-			'detailTemplate' => 'Attendee was checked into {{extraData.event.event_name}} (#{{extraData.event.event_id}} )',
+			'detailTemplate' => 'Attendee was checked into {{extraData.event.event_name}} (#{{extraData.event.event_id}} ) at {{#formatDate timestamp}}{{/formatDate}} from the Event Tickets HubSpot Integration app',
 		],
 	];
 

--- a/src/Tribe/Admin/Notices.php
+++ b/src/Tribe/Admin/Notices.php
@@ -102,7 +102,7 @@ class Notices {
 		$message = sprintf( '<div><p>%s, <a href="%s" target="_blank">%s</a>.</p></div>',
 			esc_html_x( 'HubSpot is missing the Credentials necessary to authorize your application. Please', 'First part of notice there is no settings saved for HubSpot.', 'tribe-ext-hubspot' ),
 			esc_url( $url ),
-			esc_html_x( 'set it in the settings.', 'Link text of notice there is no settings saved for HubSpot.' , 'tribe-ext-hubspot' )
+			esc_html_x( 'configure it in the settings.', 'Link text of notice there is no settings saved for HubSpot.' , 'tribe-ext-hubspot' )
 		);
 
 		return $message;

--- a/src/Tribe/Admin/Settings.php
+++ b/src/Tribe/Admin/Settings.php
@@ -216,31 +216,31 @@ class Settings {
 			$this->opts_prefix . 'app_id' => [
 				'type'            => 'text',
 				'label'           => esc_html__( 'APP ID', 'tribe-ext-hubspot' ),
-				'tooltip'         => sprintf( esc_html__( 'Enter the app id from the application created in HubSpot', 'tribe-ext-hubspot' ) ),
+				'tooltip'         => sprintf( esc_html__( 'Enter the App ID from the application created in HubSpot', 'tribe-ext-hubspot' ) ),
 				'validation_type' => 'html',
 			],
 			$this->opts_prefix . 'client_id'      => [
 				'type'            => 'text',
 				'label'           => esc_html__( 'Client ID', 'tribe-ext-hubspot' ),
-				'tooltip'         => sprintf( esc_html__( 'Enter the client id from the application created in HubSpot', 'tribe-ext-hubspot' ) ),
+				'tooltip'         => sprintf( esc_html__( 'Enter the Client ID from the application created in HubSpot', 'tribe-ext-hubspot' ) ),
 				'validation_type' => 'html',
 			],
 			$this->opts_prefix . 'client_secret'  => [
 				'type'            => 'text',
 				'label'           => esc_html__( 'Client Secret', 'tribe-ext-hubspot' ),
-				'tooltip'         => sprintf( esc_html__( 'Enter the client secret from the application created in HubSpot', 'tribe-ext-hubspot' ) ),
+				'tooltip'         => sprintf( esc_html__( 'Enter the Client Secret from the application created in HubSpot', 'tribe-ext-hubspot' ) ),
 				'validation_type' => 'html',
 			],
 			$this->opts_prefix . 'user_id' => [
 				'type'            => 'text',
 				'label'           => esc_html__( 'User ID', 'tribe-ext-hubspot' ),
-				'tooltip'         => sprintf( esc_html__( 'Enter the Developer Account User id for HubSpot', 'tribe-ext-hubspot' ) ),
+				'tooltip'         => sprintf( esc_html__( 'Enter the Developer Account User ID for HubSpot', 'tribe-ext-hubspot' ) ),
 				'validation_type' => 'html',
 			],
 			$this->opts_prefix . 'hapi_key' => [
 				'type'            => 'text',
-				'label'           => esc_html__( 'HAPI Key', 'tribe-ext-hubspot' ),
-				'tooltip'         => sprintf( esc_html__( 'Enter the Developer Account HAPI Key from the developer account in HubSpot', 'tribe-ext-hubspot' ) ),
+				'label'           => esc_html__( 'API Key', 'tribe-ext-hubspot' ),
+				'tooltip'         => sprintf( esc_html__( 'Enter the Developer Account API Key from the Developer Account in HubSpot', 'tribe-ext-hubspot' ) ),
 				'validation_type' => 'html',
 			],
 		];
@@ -507,7 +507,7 @@ class Settings {
 		$status['text']      = _x( 'Setup on hold.', 'Message displayed when HubSpot Setup has not started.', 'tribe-ext-hubspot' );
 		$status['notes']     = '&nbsp;';
 		$status_value        = isset( $options[ $type ] ) ? $options[ $type ] : null;
-		$setup_note          = _x( 'Setup can take up to 5 minutes. You may navigate away from this page and setup with continue in the background.', 'This note is displayed when HubSpot Setup is Pending or In Progress.', 'tribe-ext-hubspot' );
+		$setup_note          = _x( 'Setup can take up to 5 minutes. You may navigate away from this page—setup with continue in the background.', 'This note is displayed when HubSpot Setup is Pending or In Progress.', 'tribe-ext-hubspot' );
 
 		if ( 'complete' === $status_value ) {
 			$status['indicator'] = 'good';

--- a/src/Tribe/Setup.php
+++ b/src/Tribe/Setup.php
@@ -29,8 +29,9 @@ class Setup extends Tribe__Extension {
 	 */
 	public function construct() {
 
-		$this->add_required_plugin( 'Tribe__Tickets__Main', '4.10' );
-		$this->add_required_plugin( 'Tribe__Tickets_Plus__Main', '4.10' );
+		$this->add_required_plugin( 'Tribe__Tickets__Main', '4.11' );
+		$this->add_required_plugin( 'Tribe__Tickets_Plus__Main', '4.11' );
+		$this->add_required_plugin( 'Tribe__Events__Main', '4.9' );
 
 		// Connect into Queue Filter, if done later it does not add the handler.
 		add_action( 'tribe_process_queues', [ $this, 'queue_handlers' ] );


### PR DESCRIPTION
_Ref:_ [C#138243](https://central.tri.be/issues/138243)


This PR does the following:
- Add Release Date
- Add check if the setup is complete when checking if the api is_ready()
- Modify Checkin Timeline Description to Match the Mockup Template
- Misc Text Changes per instructions
- Call the HAPI Key, API Key as for developers HubSpot does not add the H in their labels so this is to reduce confusion. 
- Update Required ET and ET+ Version
- Add TEC as a required Plugin for the API Setting Tab