### PR TITLE
Udpate use of ->organizer_names

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -37,6 +37,10 @@ We're always interested in your feedback and our [Help Desk](https://support.the
 
 == Changelog ==
 
+= [1.0.1] TBD =
+
+* Tweak - Update code following update ons The Events Calendar 5.4.0
+
 = [1.0.0] 2019-12-17 =
 
 * Initial release

--- a/src/Tribe/Setup.php
+++ b/src/Tribe/Setup.php
@@ -31,7 +31,7 @@ class Setup extends Tribe__Extension {
 
 		$this->add_required_plugin( 'Tribe__Tickets__Main', '4.11' );
 		$this->add_required_plugin( 'Tribe__Tickets_Plus__Main', '4.11' );
-		$this->add_required_plugin( 'Tribe__Events__Main', '4.9' );
+		$this->add_required_plugin( 'Tribe__Events__Main', '5.4' );
 
 		// Connect into Queue Filter, if done later it does not add the handler.
 		add_action( 'tribe_process_queues', [ $this, 'queue_handlers' ] );

--- a/src/Tribe/Subscribe/Base.php
+++ b/src/Tribe/Subscribe/Base.php
@@ -88,7 +88,7 @@ abstract class Base {
 				'event_venue_city'           => isset( $venue->event_venue_city ) ? $venue->event_venue_city : null,
 				'event_venue_state_province' => isset( $venue->event_venue_state_province ) ? $venue->event_venue_state_province : null,
 				'event_venue_postal_code'    => isset( $venue->event_venue_postal_code ) ? $venue->event_venue_postal_code : null,
-				'event_organizer'            => implode( ', ', $event->organizers->all() ),
+				'event_organizer'            => implode( ', ', $event->organizer_names->all() ),
 				'event_is_featured'          => $event->featured,
 				'event_cost'                 => html_entity_decode( $event->cost ),
 				'event_start_datetime_utc'   => date( 'U', strtotime( 'midnight', ( \Tribe__Date_Utils::wp_strtotime( $event->start_date_utc ) ) ) ) * 1000,


### PR DESCRIPTION
Following the work done [in TEC](https://github.com/moderntribe/the-events-calendar/pull/3313),
this PR updates the usage of the `tribe_get_event()->organizers` to the `->organizer_names`.

See [TEC PR](https://github.com/moderntribe/the-events-calendar/pull/3313) for more information.