### PR TITLE
Hubspot Redirect URL Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tribe-ext-hubspot",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": "git@github.com/mt-support/tribe-ext-hubspot",
   "_zipname": "tribe-ext-hubspot",
   "_zipfoldername": "tribe-ext-hubspot",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: theeventscalendar, brianjessee
 Donate link: https://evnt.is/29
 Tags: events, calendar
 Requires at least: 5.6
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 Tested up to: 5.9.3
 Requires PHP: 7.1
 License: GPLv2 or later
@@ -36,6 +36,10 @@ Please visit our [extension library](https://theeventscalendar.com/extensions/) 
 We're always interested in your feedback and our [Help Desk](https://support.theeventscalendar.com/) are the best place to flag any issues. Do note, however, that the degree of support we provide for extensions like this one tends to be very limited.
 
 == Changelog ==
+
+= [1.0.3] TBD =
+
+* Fix - Modify the redirect url for app authorization to support the latest standards from Hubspot. [EXT-283]
 
 = [1.0.2] 2022-05-23 =
 

--- a/src/Tribe/API/Connection.php
+++ b/src/Tribe/API/Connection.php
@@ -66,11 +66,10 @@ class Connection {
 	 * Connection constructor.
 	 *
 	 * @since 1.0
-	 *
+	 * @since 1.0.3 - Modify the callback url to remove the nonce query string.
 	 */
 	public function __construct() {
-
-		$this->callback                   = wp_nonce_url( get_home_url( null, '/tribe-hubspot/' ), 'hubspot-oauth-action', 'hubspot-oauth-nonce' );
+		$this->callback                   = get_home_url( null, '/tribe-hubspot/' );
 		$this->options                    = tribe( 'tickets.hubspot' )->get_all_options();
 		$this->opts_prefix                = tribe( 'tickets.hubspot.admin.settings' )->get_options_prefix();
 		$this->app_id                     = isset( $this->options['app_id'] ) ? trim( $this->options['app_id'] ) : '';

--- a/src/Tribe/API/Oauth.php
+++ b/src/Tribe/API/Oauth.php
@@ -37,6 +37,7 @@ class Oauth {
 	 * Detect if HubSpot Endpoint and Save Access Token then Redirect to Settings
 	 *
 	 * @since 1.0
+	 * @since 1.0.3 - Remove the check for the nonce as query string is not supported with Hubspot redirect url.
 	 *
 	 * @param object $wp An object of the WordPress Query.
 	 */
@@ -48,14 +49,6 @@ class Oauth {
 
 		// Stop if we are missing the OAuth code.
 		if ( empty( $_GET['code'] ) ) {
-			die();
-		}
-
-		// Stop if the nonce is missing or is not valid.
-		if (
-			! isset( $_GET['hubspot-oauth-nonce'] ) ||
-			! wp_verify_nonce( $_GET['hubspot-oauth-nonce'], 'hubspot-oauth-action' )
-		) {
 			die();
 		}
 

--- a/src/Tribe/Admin/Settings.php
+++ b/src/Tribe/Admin/Settings.php
@@ -244,6 +244,10 @@ class Settings {
 				'tooltip'         => sprintf( esc_html__( 'Enter the Developer Account API Key from the Developer Account in HubSpot', 'tribe-ext-hubspot' ) ),
 				'validation_type' => 'html',
 			],
+			$this->opts_prefix . 'redirect_url' => [
+				'type'    => 'html',
+				'html'    => $this->get_redirect_field(),
+			],
 		];
 
 		return array_merge( (array) $fields, $hubspot_fields );
@@ -281,6 +285,29 @@ class Settings {
 		<?php
 
 		echo $this->get_status_table();
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * Get the redirect field url.
+	 *
+	 * @since 1.0.3
+	 *
+	 * @return string The redirect field url.
+	 */
+	public function get_redirect_field() {
+		$redirect_url = get_home_url( null, '/tribe-hubspot/' );
+		ob_start();
+		?>
+		<fieldset id="tribe-field-hubspot_token" class="tribe-field tribe-field-text tribe-size-medium">
+			<legend class="tribe-field-label"><?php echo esc_html_x( 'Redirect URL', 'The label for the redirct url in the settings.', 'tribe-ext-hubspot' ) ?></legend>
+			<div class="tribe-field-wrap">
+				<?php echo trim( esc_url( $redirect_url ) ); ?>
+				<p class="tooltip description"><?php echo esc_html_x( 'Add this url to the Redirect URLs field in your HubSpot App.', 'The tooltip for the redirct url in the settings.', 'tribe-ext-hubspot' ) ?></p>
+			</div>
+		</fieldset>
+		<?php
 
 		return ob_get_clean();
 	}

--- a/tribe-ext-hubspot.php
+++ b/tribe-ext-hubspot.php
@@ -4,7 +4,7 @@
  * Plugin URI:        http://m.tri.be/hubspot
  * GitHub Plugin URI: https://github.com/mt-support/tribe-ext-hubspot
  * Description:       Event Tickets and Event Tickets Plus HubSpot Integration
- * Version:           1.0.2
+ * Version:           1.0.3
  * Extension Class:   Tribe\HubSpot\Setup
  * Author:            Modern Tribe, Inc.
  * Author URI:        http://m.tri.be/1971


### PR DESCRIPTION
_Ref:_ [GTRIA-886](https://theeventscalendar.atlassian.net/browse/GTRIA-886)

-Changes to the Hubspot Authorization require the redirect url. The redirect url does not support query strings so we have to remove it from the authorization process.

https://developers.hubspot.com/changelog/upcoming-public-apps-will-require-a-redirect-url-in-the-auth-settings